### PR TITLE
Update the default validator address

### DIFF
--- a/cmd/sui-catchup/main.go
+++ b/cmd/sui-catchup/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	validator_addr  = flag.String("addr", "http://localhost:9187/metrics", "Validator metrics address")
+	validator_addr  = flag.String("addr", "http://localhost:9184/metrics", "Validator metrics address")
 	update_interval = flag.Int("interval", 1, "How often to check in seconds")
 
 	metric_channel chan *dto.MetricFamily = make(chan *dto.MetricFamily, 2)


### PR DESCRIPTION
```
 ./sui-catchup 
 Error fetching metrics: executing GET request for URL "http://localhost:9187/metrics" failed: Get "http://localhost:9187/metrics": dial tcp [::1]:9187: connect: connection refused ...

```

```
./sui-catchup  -addr http://localhost:9184/metrics
Node caught up
```